### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -10,6 +10,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/mihkels/open-messaging-benchmark/security/code-scanning/1](https://github.com/mihkels/open-messaging-benchmark/security/code-scanning/1)

In general, the fix is to explicitly add a `permissions` block to the workflow or individual jobs so that the `GITHUB_TOKEN` is limited to the least privileges needed. Since this workflow only checks out code, runs Maven, and uploads test artifacts, it does not need to write to the repository or interact with issues, PRs, etc. A minimal and sufficient configuration is `permissions: contents: read`.

The best change, without altering existing functionality, is to add a top‑level `permissions` block (applies to all jobs) near the top of `.github/workflows/pr-build-and-test.yml`, alongside `name`, `on`, and `concurrency`. This will ensure the `build` job uses a `GITHUB_TOKEN` restricted to read‑only repository contents, which is enough for `actions/checkout@v5` to pull the code. No changes to the job steps are needed, and no additional imports or dependencies are required.

Concretely:
- Edit `.github/workflows/pr-build-and-test.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `on:` block (lines 3–11) and before `concurrency:` (line 13), preserving indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
